### PR TITLE
video on entity and without relations

### DIFF
--- a/databases/README.md
+++ b/databases/README.md
@@ -42,7 +42,7 @@ This is not something that Bello will tell you, humans made all this up.
 Dog, animal, pet, humans, all these are abstractions.
 
 One way of abstracting is to think of entities and their relationships.
-An entity is an abstraction. It represents a certain category of things, like:
+An entity is an abstraction. It represents a certain category of things, often nouns, like:
 humans, women, men, animals, pets, broken bicycles, chairs, music, teachers, chewing gum, and planets.
 You can think of a **pet** as an entity that has a relationship to another entity **human**, its owner.
 More formally you can say a **human** owns **zero or more** **pets**.
@@ -53,7 +53,7 @@ Together these entities and relationships form the **domain model** for your app
 
 Learn more about entities with the following resource:
 
-{% hyf-youtube src="https://www.youtube.com/watch?v=hveVlCHZtsI" %}
+{% hyf-youtube src="https://www.youtube.com/watch?v=wOD02sezmX8" %}
 
 ## What is a database?
 


### PR DESCRIPTION

I'd like to suggest a different curriculum video for databases/entity. The current one covers relationships (which I think is too much for this short video), and goes into weak/strong and other concepts that just aren't important. More important at this stage, in one of the very first videos, is that they get what an entity and entity instance and attribute is.     

Without the current video's introduction to relationship, students will first come across the concept of join at the one hour mark of the first video in the section SQL https://hackyourfuture.github.io/study/#/databases/sql/README 
That strikes me as a reasonable way to encounter this. 

In summary, even for the lesson would suggest pairing the mix of abstract theory with the focus of the week
week1 : entities and crud. no joins. no relationships (i don't think there are joins in the homework either)
week2 : introduce joins and relationships with identifiers

Currently
At the end of the qa-prep is
"This short video explains how relationships work". That is also a reasonable place to encounter relationships